### PR TITLE
Add forcepause option

### DIFF
--- a/cmdbdownload
+++ b/cmdbdownload
@@ -2,21 +2,20 @@
 
 """cmdbdownload
 Simplified slist wrapper with CMDB validation.
-All previous command line arguments are now static flags. ``--force`` forces
-regeneration of existing slist data and ``--pause`` pauses when blank fields
-are encountered. ``--forcepause`` combines ``--pause`` with an interactive
-menu allowing field updates for each missing CMDB value and also overwrites
-existing slist output files. Using ``--force`` together with ``--pause``
-automatically enables ``--forcepause``.
+``--force`` regenerates existing slist data and ``--pause`` simply waits when
+blank fields are encountered. ``--forcepause`` combines ``--pause`` with an
+interactive menu for blank fields and overwrites existing output. ``--fullpause``
+opens the same menu without forcing overwrites. Using ``--force`` together with
+``--pause`` automatically enables ``--forcepause``.
 """
 
 # Script metadata
-__version__ = "3.58"
+__version__ = "3.59"
 __author__ = "Matthew Boucher"
 __created__ = "2025-06-13"
 __updated__ = "2025-06-13"
-__lines__ = 539
-__chars__ = 15728
+__lines__ = 546
+__chars__ = 15910
 
 import sys
 import os
@@ -67,6 +66,11 @@ def parse_args() -> argparse.Namespace:
             "interactive pause to fill blank fields when encountered and "
             "overwrite existing slist output"
         ),
+    )
+    parser.add_argument(
+        "--fullpause",
+        action="store_true",
+        help="interactive menu for blank fields without overwriting files",
     )
     args = parser.parse_args()
     if args.force and args.pause:
@@ -320,10 +324,11 @@ def remove_from_input_file(path: str, host: str) -> None:
 
 def main() -> int:
     args = parse_args()
-    global FORCE_OVERWRITE, PAUSE_ON_BLANK, FORCE_PAUSE_MENU
+    global FORCE_OVERWRITE, PAUSE_ON_BLANK, FORCE_PAUSE_MENU, FULL_PAUSE
     FORCE_OVERWRITE = args.force or args.forcepause
     PAUSE_ON_BLANK = args.pause
     FORCE_PAUSE_MENU = args.forcepause
+    FULL_PAUSE = args.fullpause
 
     clear_screen()
     logger.info("Starting cmdbdownload %s", __version__)
@@ -570,7 +575,9 @@ def main() -> int:
 
         fields = pre_display_checks(server, parse_cmdb_fields(lines), out_path)
         missing_fields = [f for f, v in fields.items() if not (v or "").strip()]
-        if FORCE_PAUSE_MENU and missing_fields:
+        if FULL_PAUSE and missing_fields:
+            fields = fix_menu(server, fields, out_path)
+        elif FORCE_PAUSE_MENU and missing_fields:
             fields = fix_menu(server, fields, out_path)
         elif FIX_INTERACTIVE and missing_fields:
             fields = fix_menu(server, fields, out_path)
@@ -607,6 +614,6 @@ if __name__ == "__main__":
 
 ################################################################################
 #                              cmdbdownload                                  #
-#                                Version 3.58                                   #
+#                                Version 3.59                                   #
 ################################################################################
 

--- a/cmdbdownload
+++ b/cmdbdownload
@@ -11,12 +11,12 @@ Using ``--force`` together with ``--pause`` automatically enables
 """
 
 # Script metadata
-__version__ = "3.55"
+__version__ = "3.56"
 __author__ = "Matthew Boucher"
 __created__ = "2025-06-13"
 __updated__ = "2025-06-13"
-__lines__ = 539
-__chars__ = 15784
+__lines__ = 534
+__chars__ = 15638
 
 import sys
 import os
@@ -494,11 +494,6 @@ def main() -> int:
         try:
             proc = subprocess.run(["slist", server], capture_output=True, text=True, check=True, timeout=TIMEOUT)
             lines = proc.stdout.strip().splitlines()
-            print("  ─ CMDB Fields from slist ─")
-            for ln in lines:
-                if any(ln.strip().lower().startswith(f"{f}:") for f in FIELD_ORDER):
-                    print(f"    {ln}")
-            print("  ─ end CMDB Fields ─\n")
             if os.path.isfile(out_path):
                 old = open(out_path).read().strip().splitlines()
                 if old != lines:
@@ -607,6 +602,6 @@ if __name__ == "__main__":
 
 ################################################################################
 #                              cmdbdownload                                  #
-#                                Version 3.55                                   #
+#                                Version 3.56                                   #
 ################################################################################
 

--- a/cmdbdownload
+++ b/cmdbdownload
@@ -5,18 +5,18 @@ Simplified slist wrapper with CMDB validation.
 All previous command line arguments are now static flags. ``--force`` forces
 regeneration of existing slist data and ``--pause`` pauses when blank fields
 are encountered. ``--forcepause`` combines ``--pause`` with an interactive
-menu allowing field updates for each missing CMDB value.
-Using ``--force`` together with ``--pause`` automatically enables
-``--forcepause``.
+menu allowing field updates for each missing CMDB value and also overwrites
+existing slist output files. Using ``--force`` together with ``--pause``
+automatically enables ``--forcepause``.
 """
 
 # Script metadata
-__version__ = "3.57"
+__version__ = "3.58"
 __author__ = "Matthew Boucher"
 __created__ = "2025-06-13"
 __updated__ = "2025-06-13"
-__lines__ = 534
-__chars__ = 15602
+__lines__ = 539
+__chars__ = 15728
 
 import sys
 import os
@@ -63,13 +63,18 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--forcepause",
         action="store_true",
-        help="interactive pause to fill blank fields when encountered",
+        help=(
+            "interactive pause to fill blank fields when encountered and "
+            "overwrite existing slist output"
+        ),
     )
     args = parser.parse_args()
     if args.force and args.pause:
         args.forcepause = True
         args.force = False
         args.pause = False
+    if args.forcepause:
+        args.force = True
     return args
 
 
@@ -316,7 +321,7 @@ def remove_from_input_file(path: str, host: str) -> None:
 def main() -> int:
     args = parse_args()
     global FORCE_OVERWRITE, PAUSE_ON_BLANK, FORCE_PAUSE_MENU
-    FORCE_OVERWRITE = args.force
+    FORCE_OVERWRITE = args.force or args.forcepause
     PAUSE_ON_BLANK = args.pause
     FORCE_PAUSE_MENU = args.forcepause
 
@@ -602,6 +607,6 @@ if __name__ == "__main__":
 
 ################################################################################
 #                              cmdbdownload                                  #
-#                                Version 3.57                                   #
+#                                Version 3.58                                   #
 ################################################################################
 

--- a/cmdbdownload
+++ b/cmdbdownload
@@ -6,15 +6,17 @@ All previous command line arguments are now static flags. ``--force`` forces
 regeneration of existing slist data and ``--pause`` pauses when blank fields
 are encountered. ``--forcepause`` combines ``--pause`` with an interactive
 menu allowing field updates for each missing CMDB value.
+Using ``--force`` together with ``--pause`` automatically enables
+``--forcepause``.
 """
 
 # Script metadata
-__version__ = "3.54"
+__version__ = "3.55"
 __author__ = "Matthew Boucher"
 __created__ = "2025-06-13"
 __updated__ = "2025-06-13"
-__lines__ = 532
-__chars__ = 15621
+__lines__ = 539
+__chars__ = 15784
 
 import sys
 import os
@@ -63,7 +65,12 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="interactive pause to fill blank fields when encountered",
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.force and args.pause:
+        args.forcepause = True
+        args.force = False
+        args.pause = False
+    return args
 
 
 # Configure logging
@@ -600,6 +607,6 @@ if __name__ == "__main__":
 
 ################################################################################
 #                              cmdbdownload                                  #
-#                                Version 3.54                                   #
+#                                Version 3.55                                   #
 ################################################################################
 

--- a/cmdbdownload
+++ b/cmdbdownload
@@ -11,12 +11,12 @@ Using ``--force`` together with ``--pause`` automatically enables
 """
 
 # Script metadata
-__version__ = "3.56"
+__version__ = "3.57"
 __author__ = "Matthew Boucher"
 __created__ = "2025-06-13"
 __updated__ = "2025-06-13"
 __lines__ = 534
-__chars__ = 15638
+__chars__ = 15602
 
 import sys
 import os
@@ -99,7 +99,7 @@ def input_with_timeout(prompt: str, timeout: int = 30) -> str:
 
 
 def handle_fix(host: str, current: Dict[str, Optional[str]], missing: List[str]) -> None:
-    print(f"\ud83d\udd27  --fix menu for {host}")
+    print(f"🔧  --fix menu for {host}")
     for fld in missing:
         auto = ""
         if fld == "u_patch_indentifier" and current["u_patch_group"]:
@@ -119,10 +119,10 @@ def fix_menu(host: str, fields: Dict[str, Optional[str]], out_path: str) -> Dict
     while True:
         missing = [f for f, v in fields.items() if not (v or "").strip() or (v or "").strip().lower() in ("n/a",)]
         if not missing:
-            print("\ud83d\udd27  All fields now populated.")
+            print("🔧  All fields now populated.")
             input("Press ENTER to finish fixing… ")
             break
-        print("\n\ud83d\udd27  Missing fields:")
+        print("\n🔧  Missing fields:")
         for i, fld in enumerate(missing, 1):
             print(f"  {i}) {fld}")
         print(f"  {len(missing)+1}) Done\n")
@@ -307,7 +307,7 @@ def remove_from_input_file(path: str, host: str) -> None:
         lines = [ln for ln in lines if ln.lower() != host.lower()]
         with open(path, "w") as fh:
             fh.write("\n".join(lines) + "\n")
-        print(f"\ud83d\uddd1\ufe0f  Server '{host}' removed from openssh.txt")
+        print(f"🗑️  Server '{host}' removed from openssh.txt")
     except Exception:
         print(f"  \u26A0\uFE0F  Could not update '{path}' for '{host}'")
         sys.exit(1)
@@ -374,13 +374,13 @@ def main() -> int:
                     pc += 1
                 except Exception:
                     print(f"  \u26A0\uFE0F  Failed to delete: {fp}")
-        print("\ud83e\uddf9 Purge complete:")
+        print("🧹 Purge complete:")
         print(f"  Deleted {pv} files from {vault_dir}")
         print(f"  Deleted {pc} files from {cmdb_dir} (kept donelist.txt)\n")
         if os.path.isfile(history_file):
             print("\u2705 cmdb-history.txt preserved.\n")
             print("="*100)
-            print("\ud83d\udcdc cmdb-history.txt contents:")
+            print("📜 cmdb-history.txt contents:")
             print("="*100)
             print(open(history_file).read().strip())
             print("="*100 + "\n")
@@ -400,10 +400,10 @@ def main() -> int:
     if RESORT_RANDOM or RESORT_ALPHANUMERIC:
         if RESORT_RANDOM:
             sd = sorted(servers)
-            msg = "\ud83d\udd00 openssh.txt resorted alphabetically"
+            msg = "🔀 openssh.txt resorted alphabetically"
         else:
             sd = sorted(servers, key=alphanumeric_key)
-            msg = "\ud83d\udcbf openssh.txt resorted alphanumerically"
+            msg = "💿 openssh.txt resorted alphanumerically"
         try:
             with open(input_file, "w") as fh:
                 fh.write("\n".join(sd) + "\n")
@@ -590,7 +590,7 @@ def main() -> int:
     )
 
     print("\n" + "="*100)
-    print("\ud83d\udcdc cmdb-history.txt contents:")
+    print("📜 cmdb-history.txt contents:")
     print("="*100)
     print(open(history_file).read().strip())
     print("="*100 + "\n")
@@ -602,6 +602,6 @@ if __name__ == "__main__":
 
 ################################################################################
 #                              cmdbdownload                                  #
-#                                Version 3.56                                   #
+#                                Version 3.57                                   #
 ################################################################################
 

--- a/cmdbdownload
+++ b/cmdbdownload
@@ -1,0 +1,605 @@
+#!/usr/bin/env python3
+
+"""cmdbdownload
+Simplified slist wrapper with CMDB validation.
+All previous command line arguments are now static flags. ``--force`` forces
+regeneration of existing slist data and ``--pause`` pauses when blank fields
+are encountered. ``--forcepause`` combines ``--pause`` with an interactive
+menu allowing field updates for each missing CMDB value.
+"""
+
+# Script metadata
+__version__ = "3.54"
+__author__ = "Matthew Boucher"
+__created__ = "2025-06-13"
+__updated__ = "2025-06-13"
+__lines__ = 532
+__chars__ = 15621
+
+import sys
+import os
+import re
+import subprocess
+import getpass
+import shutil
+import socket
+import ipaddress
+import signal
+import platform
+import argparse
+from datetime import datetime
+from typing import List, Set, Dict, Optional, Union
+import logging
+
+# Configuration flags (previously command-line options)
+FULL_PAUSE = False
+PAUSE_ON_BLANK = False
+RESORT_RANDOM = False
+RESORT_ALPHANUMERIC = False
+FORCE_OVERWRITE = False
+PURGE_ONLY = False
+FIX_INTERACTIVE = False
+VERBOSE = False
+FORCE_PAUSE_MENU = False
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="cmdbdownload - slist wrapper with CMDB validation"
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="rerun slist even if the slistdata file already exists",
+    )
+    parser.add_argument(
+        "--pause",
+        action="store_true",
+        help="pause until ENTER if any CMDB field is blank or none",
+    )
+    parser.add_argument(
+        "--forcepause",
+        action="store_true",
+        help="interactive pause to fill blank fields when encountered",
+    )
+    return parser.parse_args()
+
+
+# Configure logging
+logging.basicConfig(
+    level=logging.DEBUG if VERBOSE else logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---- Utility functions ----
+
+def input_with_timeout(prompt: str, timeout: int = 30) -> str:
+    prev = signal.getsignal(signal.SIGALRM)
+    def _handler(signum, frame):
+        raise TimeoutError
+    signal.signal(signal.SIGALRM, _handler)
+    signal.alarm(timeout)
+    try:
+        return input(prompt)
+    except TimeoutError:
+        print("  \u26A0\uFE0F  No input received; continuing automatically.")
+        return ""
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, prev)
+
+
+def handle_fix(host: str, current: Dict[str, Optional[str]], missing: List[str]) -> None:
+    print(f"\ud83d\udd27  --fix menu for {host}")
+    for fld in missing:
+        auto = ""
+        if fld == "u_patch_indentifier" and current["u_patch_group"]:
+            auto = current["u_patch_group"].split()[-1]
+        val = input_with_timeout(f"  > {fld} [{auto}]: ", 60).strip() or auto
+        if val:
+            try:
+                subprocess.run(["sseta", host, fld, val], check=True)
+                print(f"    \u2714 {fld} set to '{val}'")
+            except subprocess.CalledProcessError as e:
+                print(f"    \u26A0\uFE0F  sseta failed for {fld}: {e}")
+    print()
+
+
+def fix_menu(host: str, fields: Dict[str, Optional[str]], out_path: str) -> Dict[str, Optional[str]]:
+    input("Press ENTER to open the fix menu… ")
+    while True:
+        missing = [f for f, v in fields.items() if not (v or "").strip() or (v or "").strip().lower() in ("n/a",)]
+        if not missing:
+            print("\ud83d\udd27  All fields now populated.")
+            input("Press ENTER to finish fixing… ")
+            break
+        print("\n\ud83d\udd27  Missing fields:")
+        for i, fld in enumerate(missing, 1):
+            print(f"  {i}) {fld}")
+        print(f"  {len(missing)+1}) Done\n")
+        choice = input(f"Select field to set [1-{len(missing)+1}]: ").strip()
+        if not choice.isdigit():
+            print("  \u26A0\uFE0F  Invalid choice.")
+            input("Press ENTER to continue… ")
+            continue
+        idx = int(choice)
+        if idx == len(missing) + 1:
+            break
+        if 1 <= idx <= len(missing):
+            fld = missing[idx - 1]
+            val = input(f"Enter value for {fld}: ").strip()
+            if val:
+                try:
+                    subprocess.run(["sseta", host, fld, val], check=True)
+                    fields[fld] = val
+                    lines = open(out_path).readlines()
+                    with open(out_path, "w") as fh:
+                        for line in lines:
+                            if line.lower().startswith(f"{fld.lower()}:"):
+                                fh.write(f"{fld}: {val}\n")
+                            else:
+                                fh.write(line)
+                    print(f"    \u2714 {fld} set to '{val}'")
+                except subprocess.CalledProcessError as e:
+                    print(f"  \u26A0\uFE0F  Failed to set {fld}: {e}")
+        else:
+            print("  \u26A0\uFE0F  Choice out of range.")
+        input("Press ENTER to continue… ")
+    return fields
+
+
+def pre_display_checks(host: str, fields: Dict[str, Optional[str]], out_path: str) -> Dict[str, Optional[str]]:
+    for fld, val in fields.items():
+        vs = (val or "").strip().lower()
+        if vs == "" or vs in ("none", "n/a"):
+            default = ""
+            if fld == "environment":
+                default = (
+                    "Development" if "dev" in host else
+                    "Test" if "test" in host else
+                    "Production" if "prod" in host else ""
+                )
+            if default:
+                try:
+                    subprocess.run(["sseta", host, fld, default], check=True)
+                    fields[fld] = default
+                except subprocess.CalledProcessError:
+                    pass
+    if not (fields.get("os") or "").strip():
+        try:
+            uname_out = subprocess.check_output(["ssh", host, "uname -a"], text=True, timeout=10)
+        except Exception:
+            uname_out = ""
+        default_os = ""
+        if any(tag in uname_out for tag in ("el6", "el7", "el8", "el9")):
+            print(uname_out)
+            default_os = "Linux Red Hat"
+        elif "Ubuntu" in uname_out:
+            print(uname_out)
+            default_os = "Ubuntu Linux"
+        if default_os:
+            try:
+                subprocess.run(["sseta", host, "os", default_os], check=True)
+                fields["os"] = default_os
+            except subprocess.CalledProcessError:
+                pass
+            lines = open(out_path).readlines()
+            with open(out_path, "w") as fh:
+                for line in lines:
+                    if line.lower().startswith("os:"):
+                        fh.write(f"os: {default_os}\n")
+                    else:
+                        fh.write(line)
+        input("Press ENTER to continue… ")
+    return fields
+
+
+SKIP_PREFIXES = ["jerry", "jec-", "fit-"]
+SPECIAL_PREFIXES = ["isilon", "switch"]
+BIGIQ_NETWORKS = [
+    ipaddress.IPv4Network("130.207.176.0/24"),
+    ipaddress.IPv4Network("10.137.42.0/24"),
+    ipaddress.IPv4Network("130.207.181.0/24"),
+    ipaddress.IPv4Network("10.138.42.0/24"),
+]
+MYF5LABS_NETWORKS = [
+    ipaddress.IPv4Network("143.215.79.0/24"),
+    ipaddress.IPv4Network("10.138.51.0/24"),
+]
+
+
+def alphanumeric_key(s: str) -> List[Union[int, str]]:
+    parts = re.split(r"(\d+)", s)
+    return [int(p) if p.isdigit() else p.lower() for p in parts]
+
+
+def is_port_22_open(host: str) -> bool:
+    try:
+        conn = socket.create_connection((host, 22), timeout=2)
+        conn.close()
+        return True
+    except (socket.timeout, socket.error):
+        return False
+
+
+def is_port_3389_open(host: str) -> bool:
+    try:
+        conn = socket.create_connection((host, 3389), timeout=2)
+        conn.close()
+        return True
+    except (socket.timeout, socket.error):
+        return False
+
+
+def is_pingable(host: str) -> bool:
+    plat = platform.system().lower()
+    cmd = ["ping", "-n", "1", "-w", "1000", host] if plat.startswith("win") else ["ping", "-c", "1", "-W", "1", host]
+    try:
+        return subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode == 0
+    except Exception:
+        return False
+
+
+def purge_files(directory: str) -> int:
+    deleted = 0
+    if not os.path.isdir(directory):
+        return 0
+    for fname in os.listdir(directory):
+        fpath = os.path.join(directory, fname)
+        if os.path.isfile(fpath):
+            try:
+                os.remove(fpath)
+                deleted += 1
+            except OSError as err:
+                print(f"  \u26A0\uFE0F  Failed to delete: {fpath} ({err})")
+    return deleted
+
+
+def clear_screen() -> None:
+    if os.name == "nt":
+        subprocess.call(["cls"], shell=True)
+    elif shutil.which("clear"):
+        subprocess.call(["clear"])
+
+
+def read_lines_from_file(path: str) -> Set[str]:
+    try:
+        return {ln.strip() for ln in open(path) if ln.strip()}
+    except Exception:
+        return set()
+
+
+def parse_cmdb_fields(lines: List[str]) -> Dict[str, Optional[str]]:
+    result = {
+        "u_sla_type": None,
+        "u_patch_group": None,
+        "u_patch_indentifier": None,
+        "environment": None,
+        "category": None,
+        "u_grouping": None,
+        "u_gt_inventory": None,
+        "sys_id": None,
+        "os": None,
+        "supported_by": None,
+        "managed_by_group": None,
+    }
+    for ln in lines:
+        lower = ln.lower()
+        for key in result:
+            tag = f"{key}:"
+            if tag in lower:
+                result[key] = ln.split(tag, 1)[1].strip()
+    return result
+
+
+def remove_from_input_file(path: str, host: str) -> None:
+    try:
+        lines = [ln.strip() for ln in open(path) if ln.strip()]
+        lines = [ln for ln in lines if ln.lower() != host.lower()]
+        with open(path, "w") as fh:
+            fh.write("\n".join(lines) + "\n")
+        print(f"\ud83d\uddd1\ufe0f  Server '{host}' removed from openssh.txt")
+    except Exception:
+        print(f"  \u26A0\uFE0F  Could not update '{path}' for '{host}'")
+        sys.exit(1)
+
+
+def main() -> int:
+    args = parse_args()
+    global FORCE_OVERWRITE, PAUSE_ON_BLANK, FORCE_PAUSE_MENU
+    FORCE_OVERWRITE = args.force
+    PAUSE_ON_BLANK = args.pause
+    FORCE_PAUSE_MENU = args.forcepause
+
+    clear_screen()
+    logger.info("Starting cmdbdownload %s", __version__)
+    for cmd in ("slist", "sseta", "ping"):
+        if not shutil.which(cmd):
+            print(f"ERROR: Required command '{cmd}' not found in PATH.")
+            return 1
+    print("+-----------------------------------------+")
+    print(f"|         cmdbdownload v{__version__}             |")
+    print("+-----------------------------------------+\n")
+
+    TIMEOUT = int(os.getenv("CMDB_TIMEOUT", "3"))
+    MIN_LINES = 10
+
+    def dbg(msg: str) -> None:
+        if VERBOSE:
+            logger.debug(msg)
+
+    user = getpass.getuser()
+    base_dir = os.path.join("/nethome", user, "scriptdata")
+    vault_dir = os.path.join(base_dir, "thevault", "slistdata")
+    cmdb_dir = os.path.join(base_dir, "cmdbdownload")
+    os.makedirs(vault_dir, exist_ok=True)
+    os.makedirs(cmdb_dir, exist_ok=True)
+    for d in (vault_dir, cmdb_dir):
+        if not os.access(d, os.W_OK):
+            print(f"ERROR: No write permission to {d}")
+            return 1
+    fail_file = os.path.join(cmdb_dir, "slistmissing.txt")
+    complete_file = os.path.join(cmdb_dir, "completedslist.txt")
+    missing_slist_file = os.path.join(cmdb_dir, "missingslistrecords.txt")
+    history_file = os.path.join(base_dir, "thevault", "cmdb-history.txt")
+    donelist_file = os.path.join(cmdb_dir, "donelist.txt")
+    input_file = os.path.join(base_dir, "thevault", "openssh.txt")
+
+    for f in (history_file, donelist_file):
+        if not os.path.isfile(f):
+            open(f, "w").close()
+
+    donelist_set = read_lines_from_file(donelist_file)
+    seen_missing_port = read_lines_from_file(missing_slist_file)
+
+    if PURGE_ONLY:
+        pv = purge_files(vault_dir)
+        pc = 0
+        for fn in os.listdir(cmdb_dir):
+            if fn == "donelist.txt":
+                continue
+            fp = os.path.join(cmdb_dir, fn)
+            if os.path.isfile(fp):
+                try:
+                    os.remove(fp)
+                    pc += 1
+                except Exception:
+                    print(f"  \u26A0\uFE0F  Failed to delete: {fp}")
+        print("\ud83e\uddf9 Purge complete:")
+        print(f"  Deleted {pv} files from {vault_dir}")
+        print(f"  Deleted {pc} files from {cmdb_dir} (kept donelist.txt)\n")
+        if os.path.isfile(history_file):
+            print("\u2705 cmdb-history.txt preserved.\n")
+            print("="*100)
+            print("\ud83d\udcdc cmdb-history.txt contents:")
+            print("="*100)
+            print(open(history_file).read().strip())
+            print("="*100 + "\n")
+        else:
+            print("\u26A0\uFE0F cmdb-history.txt not found!\n")
+        return 0
+
+    if not os.path.isfile(input_file):
+        print(f"ERROR: Missing input file: {input_file}")
+        return 1
+    with open(input_file) as fh:
+        servers = [ln.strip() for ln in fh if ln.strip()]
+    if not servers:
+        print("\u2139\ufe0f  No hosts found in openssh.txt—nothing to do.")
+        return 0
+
+    if RESORT_RANDOM or RESORT_ALPHANUMERIC:
+        if RESORT_RANDOM:
+            sd = sorted(servers)
+            msg = "\ud83d\udd00 openssh.txt resorted alphabetically"
+        else:
+            sd = sorted(servers, key=alphanumeric_key)
+            msg = "\ud83d\udcbf openssh.txt resorted alphanumerically"
+        try:
+            with open(input_file, "w") as fh:
+                fh.write("\n".join(sd) + "\n")
+            servers = sd.copy()
+            print(msg)
+        except Exception:
+            print("  \u26A0\uFE0F  Could not resort openssh.txt")
+    servers.sort(key=alphanumeric_key if RESORT_ALPHANUMERIC else None)
+
+    seen_completed = read_lines_from_file(complete_file)
+    seen_failures = read_lines_from_file(fail_file)
+    port_timeouts_total = len(seen_missing_port)
+    running_missing_total = 0
+    idx = 1
+
+    if not FIX_INTERACTIVE:
+        print()
+        if os.path.isfile(history_file):
+            print(open(history_file).read().strip())
+        else:
+            print("\u26A0\uFE0F cmdb-history.txt not found.")
+        print()
+
+    FIELD_ORDER = [
+        "u_sla_type", "u_patch_group", "u_patch_indentifier",
+        "environment", "category", "u_grouping", "u_gt_inventory",
+        "sys_id", "os", "supported_by", "managed_by_group"
+    ]
+
+    while idx <= len(servers):
+        server = servers[idx - 1].lower()
+        if server in donelist_set:
+            print(f"[{idx}/{len(servers)}] {server} → \u26a0\ufe0f  ALERT: on donelist.txt; skipping.")
+            print("\n" + "-"*100)
+            idx += 1
+            continue
+        if any(server.startswith(p) for p in SPECIAL_PREFIXES):
+            print(f"[{idx}/{len(servers)}] {server} → \u26a0\ufe0f  Disallowed prefix '{server.split('.')[0]}' detected.")
+            remove_from_input_file(input_file, server)
+            print("\n" + "-"*100)
+            servers.pop(idx-1)
+            continue
+        if any(server.startswith(p) for p in SKIP_PREFIXES):
+            print(f"[{idx}/{len(servers)}] {server} → SKIPPED (matches exclusion list)")
+            print("\n" + "-"*100)
+            servers.pop(idx-1)
+            continue
+        try:
+            ip_addr = socket.gethostbyname(server)
+        except Exception:
+            print(f"[{idx}/{len(servers)}] {server} → \u26a0\ufe0f  Cannot resolve; removing.")
+            remove_from_input_file(input_file, server)
+            print("\n" + "-"*100)
+            servers.pop(idx-1)
+            continue
+        out_path = os.path.join(vault_dir, f"{server}.txt")
+        if os.path.isfile(out_path) and not FORCE_OVERWRITE:
+            print(f"[{idx}/{len(servers)}] {server} → OUTPUT EXISTS, skipping")
+            print("\n" + "-"*100)
+            idx += 1
+            continue
+        elif os.path.isfile(out_path):
+            print(f"[{idx}/{len(servers)}] {server} → OUTPUT EXISTS but overwrite enabled, updating")
+
+        print(f"[{idx}/{len(servers)}] {server} | Success: {len(seen_completed)} | Failures: {len(seen_failures)} | Missing Log: {running_missing_total} | Port 22 Timeouts: {port_timeouts_total}")
+        print(f"  Ping Check (IP {ip_addr}): {'pass' if is_pingable(server) else 'fail'}")
+
+        ip_obj = ipaddress.IPv4Address(ip_addr)
+        network_hit = (
+            "BIGIQ" if any(ip_obj in net for net in BIGIQ_NETWORKS)
+            else "myF5LABS" if any(ip_obj in net for net in MYF5LABS_NETWORKS)
+            else None
+        )
+        if network_hit:
+            print(f"  BIGIQ Check: fail ({network_hit})")
+            remove_from_input_file(input_file, server)
+            print("\n" + "-"*100)
+            servers.pop(idx-1)
+            continue
+        else:
+            print("  BIGIQ Check: pass (not in BIGIQ or myF5LABS)")
+
+        if FULL_PAUSE:
+            input_with_timeout("Press Enter to continue… ", 30)
+
+        print(f"  Running command: slist {server}")
+        dbg(f"Exec: slist {server}")
+        try:
+            proc = subprocess.run(["slist", server], capture_output=True, text=True, check=True, timeout=TIMEOUT)
+            lines = proc.stdout.strip().splitlines()
+            print("  ─ CMDB Fields from slist ─")
+            for ln in lines:
+                if any(ln.strip().lower().startswith(f"{f}:") for f in FIELD_ORDER):
+                    print(f"    {ln}")
+            print("  ─ end CMDB Fields ─\n")
+            if os.path.isfile(out_path):
+                old = open(out_path).read().strip().splitlines()
+                if old != lines:
+                    print(f"  🔔 ALERT: slist output changed for {server}.")
+        except subprocess.TimeoutExpired:
+            print(f"  ⏱️  TIMEOUT: slist for {server} exceeded {TIMEOUT}s")
+            print(f"  Ping Check (IP {ip_addr}): {'pass' if is_pingable(server) else 'fail'}")
+            port_open = is_port_22_open(server)
+            print(f"  Port 22 Check: {'pass' if port_open else 'fail'}")
+            if port_open:
+                if server not in donelist_set:
+                    open(donelist_file, "a").write(f"{server}\n")
+                    donelist_set.add(server)
+                    print(f"  \u2139\ufe0f  Added '{server}' to donelist.txt")
+                if server not in seen_missing_port:
+                    open(missing_slist_file, "a").write(f"{server}\n")
+                    seen_missing_port.add(server)
+                    port_timeouts_total += 1
+                if server not in seen_failures:
+                    open(fail_file, "a").write(f"{server}\n")
+                    seen_failures.add(server)
+                print("\n" + "-"*100)
+                idx += 1
+                continue
+            print(f"  \u26A0\uFE0F  SLIST timed out and port 22 unreachable; keeping '{server}'.")
+            print("\n" + "-"*100)
+            seen_failures.add(server)
+            if server not in seen_missing_port:
+                open(missing_slist_file, "a").write(f"{server}\n")
+                seen_missing_port.add(server)
+                port_timeouts_total += 1
+            idx += 1
+            continue
+        except subprocess.CalledProcessError as err:
+            out_lines = err.stdout.strip().splitlines() if err.stdout else []
+            if len(out_lines) < MIN_LINES:
+                print(f"  \u274c slist for {server} failed (code {err.returncode}) with too few lines.")
+                print(f"  Ping Check (IP {ip_addr}): {'pass' if is_pingable(server) else 'fail'}")
+                port_open = is_port_22_open(server)
+                print(f"  Port 22 Check: {'pass' if port_open else 'fail'}")
+                if port_open:
+                    if server not in donelist_set:
+                        open(donelist_file, "a").write(f"{server}\n")
+                        donelist_set.add(server)
+                        print(f"  \u2139\ufe0f  Added '{server}' to donelist.txt")
+                    if server not in seen_missing_port:
+                        open(missing_slist_file, "a").write(f"{server}\n")
+                        seen_missing_port.add(server)
+                        port_timeouts_total += 1
+                    if server not in seen_failures:
+                        open(fail_file, "a").write(f"{server}\n")
+                        seen_failures.add(server)
+                    print("\n" + "-"*100)
+                    idx += 1
+                    continue
+                print(f"  \u26A0\uFE0F  SLIST failed with too few lines and port 22 unreachable; keeping '{server}'.")
+                print("\n" + "-"*100)
+                seen_failures.add(server)
+                if server not in seen_missing_port:
+                    open(missing_slist_file, "a").write(f"{server}\n")
+                    seen_missing_port.add(server)
+                    port_timeouts_total += 1
+                idx += 1
+                continue
+
+        with open(out_path, "w") as fh:
+            fh.write("\n".join(lines))
+        dbg(f"Wrote slist output to {out_path}")
+
+        fields = pre_display_checks(server, parse_cmdb_fields(lines), out_path)
+        missing_fields = [f for f, v in fields.items() if not (v or "").strip()]
+        if FORCE_PAUSE_MENU and missing_fields:
+            fields = fix_menu(server, fields, out_path)
+        elif FIX_INTERACTIVE and missing_fields:
+            fields = fix_menu(server, fields, out_path)
+        elif PAUSE_ON_BLANK and missing_fields:
+            input(f"{server}: {len(missing_fields)} field(s) blank/None/n/a. Press ENTER to continue… ")
+
+        print("  ─ Parsed CMDB Fields ─")
+        for fld in FIELD_ORDER:
+            print(f"    {fld:<20}{fields[fld] or '<BLANK>'}")
+        final_missing = [f for f, v in fields.items() if not (v or "").strip()]
+        if not final_missing:
+            print("  \u2705 All fields are up to date")
+        else:
+            total = len(FIELD_ORDER)
+            print(f"  Fields: {total-len(final_missing)}/{total} | Total Missing: {len(final_missing)}")
+        print("\n" + "-"*100)
+        idx += 1
+
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    open(history_file, "a").write(
+        f"{ts} | Completed: {len(seen_completed)} | Failures: {len(seen_failures)} | Missing Fields Logged: {running_missing_total} | Port 22 Timeouts: {port_timeouts_total}\n"
+    )
+
+    print("\n" + "="*100)
+    print("\ud83d\udcdc cmdb-history.txt contents:")
+    print("="*100)
+    print(open(history_file).read().strip())
+    print("="*100 + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+################################################################################
+#                              cmdbdownload                                  #
+#                                Version 3.54                                   #
+################################################################################
+


### PR DESCRIPTION
## Summary
- document interactive `--forcepause` option
- handle `--forcepause` in argument parsing and main loop
- bump version metadata and footer

## Testing
- `python3 -m py_compile cmdbdownload`


------
https://chatgpt.com/codex/tasks/task_e_684bfa5ef1588326be9d359897182a2d