### PR TITLE
Query managed_by via slist and map emails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.log
+__pycache__/
+templist.txt

--- a/automail
+++ b/automail
@@ -1,0 +1,578 @@
+#!/usr/bin/env python3
+####################################
+# automail - Version 1.34          #
+####################################
+# Change Log (last 10 entries)
+# 1.34 - Display manager email from managed_by-emailaddress.txt.
+# 1.33 - Provide menu for --cc with operations@oit.gatech.edu or manual entry.
+# 1.32 - Add --cc argument and parse Cc from templates.
+# 1.31 - Map managed_by values to email addresses via managed_by-emailaddress.txt.
+# 1.30 - Ensure default signature exists and display its contents.
+# 1.29 - Show managed_by info via slist for each server.
+# 1.28 - Remove timestamp from server progress line.
+# 1.27 - Add --template menu to manage email templates.
+# 1.26 - GUI menu offers all CLI options.
+# 1.25 - Show line counts when listing files for --load.
+#
+# Reads from:
+#   /nethome/mboucher3/scriptdata/automail/lists/<file>      (server lists)
+#   /nethome/mboucher3/scriptdata/automail/templates/<file>  (email templates)
+#   /nethome/mboucher3/scriptdata/automail/signatures/<file> (email signatures)
+#   templist.txt                                             (temporary server list)
+#   managed_by-emailaddress.txt                              (manager email map)
+# Writes to:
+#   /nethome/mboucher3/scriptdata/automail/templates/<file>  (email templates)
+#   /nethome/mboucher3/scriptdata/automail/signatures/<file> (email signatures)
+#   templist.txt                                             (temporary server list)
+#   managed_by-emailaddress.txt                              (manager email map)
+#
+# Arguments:
+#   names                 Server names
+#   --gui                 Run in interactive CLI mode
+#   --list                Edit server list in vi
+#   --last                Reuse server list from last --list run
+#   --load                Select or create a list file in the lists directory
+#   --template            Manage template files in the templates directory
+#   --cc                  Choose CC email address
+#
+# Simple script to process server lists and display management
+# information. The script can be run from the command line, for example:
+#
+#     ./automail server1 server2
+#
+# Use ``--gui`` to enter names interactively instead of supplying them on
+# the command line.
+
+from __future__ import annotations
+
+import argparse
+import curses
+import getpass
+import os
+import subprocess
+from pathlib import Path
+
+SCRIPT_NAME = Path(__file__).name
+VERSION = "1.34"
+VERSION_TAG = f"{SCRIPT_NAME} v{VERSION}"
+CURRENT_USER = getpass.getuser()
+
+LISTS_DIR = Path("/nethome/mboucher3/scriptdata/automail/lists")
+if not LISTS_DIR.exists():
+    LISTS_DIR = Path(__file__).with_name("lists")
+TEMPLATES_DIR = Path("/nethome/mboucher3/scriptdata/automail/templates")
+if not TEMPLATES_DIR.exists():
+    TEMPLATES_DIR = Path(__file__).with_name("templates")
+SIGNATURES_DIR = Path("/nethome/mboucher3/scriptdata/automail/signatures")
+if not SIGNATURES_DIR.exists():
+    SIGNATURES_DIR = Path(__file__).with_name("signatures")
+DEFAULT_SIGNATURE_PATH = SIGNATURES_DIR / "defaultsignature.txt"
+DEFAULT_TEMPLATE_PATH = TEMPLATES_DIR / "default_template.txt"
+TEMPLIST_PATH = Path("templist.txt")
+MANAGER_EMAIL_PATH = Path(__file__).with_name("managed_by-emailaddress.txt")
+
+ARGUMENTS_INFO = [
+    ("names", "Server names"),
+    ("--gui", "Run in interactive CLI mode"),
+    ("--list", "Edit server list in vi"),
+    ("--last", "Reuse server list from last --list run"),
+    ("--load", "Select or create a list file in the lists directory"),
+    ("--template", "Manage template files in the templates directory"),
+    ("--cc", "Choose CC email address"),
+]
+
+ARGUMENTS_TEXT = "Arguments:\n" + "\n".join(
+    f"  {name:<17} {desc}" for name, desc in ARGUMENTS_INFO
+)
+
+
+def make_banner(text: str) -> str:
+    border = "#" * (len(text) + 4)
+    return f"{border}\\n# {text} #\\n{border}"
+
+
+HEADER = make_banner(VERSION_TAG)
+FOOTER = HEADER
+
+
+def display_banner() -> None:
+    os.system("cls" if os.name == "nt" else "clear")
+    print(HEADER)
+    print(f"Current user: {CURRENT_USER}")
+    print()
+    print(ARGUMENTS_TEXT)
+    print()
+
+
+def ensure_default_signature(*, quiet: bool = False) -> str:
+    """Ensure default signature exists and optionally display its contents."""
+    SIGNATURES_DIR.mkdir(parents=True, exist_ok=True)
+    if not DEFAULT_SIGNATURE_PATH.exists():
+        print("No signature found. Launching vi to create defaultsignature.txt.")
+        subprocess.run(["vi", str(DEFAULT_SIGNATURE_PATH)])
+        if not DEFAULT_SIGNATURE_PATH.exists():
+            DEFAULT_SIGNATURE_PATH.touch()
+    with DEFAULT_SIGNATURE_PATH.open() as f:
+        signature = f.read().strip()
+    if not quiet:
+        print("Signature:\n" + signature)
+    return signature
+
+
+def choose_cc_address() -> str | None:
+    """Prompt user to select a CC address."""
+    print("Select CC email:")
+    print("1. operations@oit.gatech.edu")
+    print("2. Enter address manually")
+    print("0. No CC")
+    while True:
+        choice = input("Choice: ").strip()
+        if choice == "1":
+            return "operations@oit.gatech.edu"
+        if choice == "2":
+            addr = input("Enter CC email: ").strip()
+            return addr or None
+        if choice in {"0", ""}:
+            return None
+        print("Invalid selection. Try again.")
+
+
+def load_template(path: Path) -> dict[str, str | None]:
+    """Load sender, subject, optional cc, and body from a template."""
+    TEMPLATES_DIR.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        return {"sender": "", "subject": "", "cc": None, "body": ""}
+    sender = ""
+    subject = ""
+    cc: str | None = None
+    body_lines: list[str] = []
+    with path.open() as f:
+        for line in f:
+            lower = line.lower()
+            if lower.startswith("sender:"):
+                sender = line.split(":", 1)[1].strip()
+            elif lower.startswith("cc:"):
+                value = line.split(":", 1)[1].strip()
+                if value:
+                    cc = value
+            elif lower.startswith("subject:"):
+                subject = line.split(":", 1)[1].strip()
+            else:
+                body_lines.append(line.rstrip("\n"))
+    body = "\n".join(body_lines).strip()
+    return {"sender": sender, "subject": subject, "cc": cc, "body": body}
+
+
+def lookup_manager_email(manager: str) -> str:
+    """Return email address for manager, prompting and storing if missing."""
+    MANAGER_EMAIL_PATH.touch(exist_ok=True)
+    mapping: dict[str, str] = {}
+    with MANAGER_EMAIL_PATH.open() as f:
+        for line in f:
+            if "," in line:
+                name, email = line.strip().split(",", 1)
+                mapping[name.strip()] = email.strip()
+    if manager in mapping:
+        email = mapping[manager]
+        print(f"Email for {manager}: {email}")
+        return email
+    email = input(f"Enter email address for '{manager}': ").strip()
+    with MANAGER_EMAIL_PATH.open("a") as f:
+        f.write(f"{manager},{email}\n")
+    print(f"Email for {manager}: {email}")
+    return email
+
+
+def show_managed_by(names: list[str]) -> None:
+    """Run slist for each server and display its managed_by field."""
+    total = len(names)
+    for index, server in enumerate(names, 1):
+        print(f"{index}/{total} Server: {server}")
+        try:
+            result = subprocess.run(
+                ["slist", server],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+            output = result.stdout
+        except FileNotFoundError:
+            managed_by = "slist command not found"
+        else:
+            managed_by = "Unknown"
+            for line in output.splitlines():
+                if "managed_by" in line.lower():
+                    managed_by = line.split(":", 1)[1].strip() if ":" in line else line.split()[-1]
+                    break
+        print(f"Managed By: {managed_by}")
+        if managed_by not in {"slist command not found", "Unknown"}:
+            lookup_manager_email(managed_by)
+        print("-" * 40)
+
+
+def count_lines(path: Path) -> int:
+    """Return the number of non-empty lines in a file."""
+    with path.open() as f:
+        return sum(1 for line in f if line.strip())
+
+
+def run_gui(args: argparse.Namespace) -> None:
+    """Curses-based interface with menu options for all CLI arguments."""
+
+    stdscr = curses.initscr()
+    curses.noecho()
+    curses.cbreak()
+    stdscr.keypad(True)
+
+    def prompt(text: str) -> str:
+        curses.echo()
+        h, w = stdscr.getmaxyx()
+        stdscr.addstr(h - 1, 0, text)
+        stdscr.clrtoeol()
+        value = stdscr.getstr(h - 1, len(text)).decode().strip()
+        curses.noecho()
+        return value
+
+    def enter_names() -> None:
+        nonlocal names
+        names = []
+        while True:
+            name = prompt("Name (blank to finish): ")
+            if not name:
+                break
+            names.append(name)
+        output.append(f"Collected {len(names)} names")
+
+    def edit_list() -> None:
+        nonlocal names
+        if TEMPLIST_PATH.exists():
+            TEMPLIST_PATH.unlink()
+        subprocess.run(["vi", str(TEMPLIST_PATH)])
+        if not TEMPLIST_PATH.exists():
+            TEMPLIST_PATH.touch()
+        with TEMPLIST_PATH.open() as f:
+            names = [line.strip() for line in f if line.strip()]
+        output.append(
+            f"Processing file: {TEMPLIST_PATH.name} ({len(names)} lines)"
+        )
+
+    def reuse_last() -> None:
+        nonlocal names
+        if not TEMPLIST_PATH.exists():
+            subprocess.run(["vi", str(TEMPLIST_PATH)])
+            if not TEMPLIST_PATH.exists():
+                TEMPLIST_PATH.touch()
+        with TEMPLIST_PATH.open() as f:
+            names = [line.strip() for line in f if line.strip()]
+        output.append(
+            f"Processing file: {TEMPLIST_PATH.name} ({len(names)} lines)"
+        )
+
+    def load_from_dir() -> None:
+        nonlocal names
+        path = select_list_file()
+        if path is None:
+            output.append("No file selected")
+            return
+        with path.open() as f:
+            names = [line.strip() for line in f if line.strip()]
+        output.append(f"Processing file: {path.name} ({len(names)} lines)")
+
+    def manage_templates() -> None:
+        path = select_template_file()
+        if path is None:
+            output.append("No template selected")
+        else:
+            output.append(f"Selected template: {path.name}")
+
+    def select_cc_gui() -> str:
+        output.append("Select CC email:")
+        output.append("1. operations@oit.gatech.edu")
+        output.append("2. Enter address manually")
+        output.append("0. No CC")
+        choice = prompt("Choice: ")
+        if choice == "1":
+            return "operations@oit.gatech.edu"
+        if choice == "2":
+            return prompt("Enter CC email: ").strip()
+        return ""
+
+    def set_cc() -> None:
+        nonlocal cc
+        cc = select_cc_gui()
+        if cc:
+            output.append(f"CC set to: {cc}")
+        else:
+            output.append("CC cleared")
+
+    def show_now() -> None:
+        if names:
+            show_managed_by(names)
+            output.append(f"Checked {len(names)} servers")
+        else:
+            output.append("No server names to check")
+
+    def quit_gui() -> str:
+        return "quit"
+
+    signature = ensure_default_signature(quiet=True)
+    template = load_template(DEFAULT_TEMPLATE_PATH)
+    cc = template.get("cc") or ""
+    names: list[str] = args.names or []
+    output: list[str] = ["Signature:"] + signature.splitlines()
+    if args.cc:
+        cc = select_cc_gui()
+        if cc:
+            output.append(f"CC set to: {cc}")
+        else:
+            output.append("CC cleared")
+    elif cc:
+        output.append(f"CC: {cc}")
+    handlers = [
+        enter_names,
+        edit_list,
+        reuse_last,
+        load_from_dir,
+        manage_templates,
+        set_cc,
+        show_now,
+        quit_gui,
+    ]
+
+    try:
+        current = 0
+        while True:
+            stdscr.clear()
+            h, w = stdscr.getmaxyx()
+            stdscr.addstr(0, 0, HEADER)
+            stdscr.addstr(HEADER.count("\n") + 1, 0, f"Current user: {CURRENT_USER}")
+            arg_lines = ARGUMENTS_TEXT.splitlines()
+            arg_start = HEADER.count("\n") + 3
+            for i, line in enumerate(arg_lines):
+                stdscr.addstr(arg_start + i, 0, line)
+            menu_start = arg_start + len(arg_lines) + 1
+            labels = [
+                "Enter server names",
+                "Edit server list in vi",
+                "Reuse last server list",
+                "Load list from directory",
+                "Manage templates",
+                "Set CC email",
+                "Show managed_by info",
+                "Quit",
+            ]
+            for idx, label in enumerate(labels):
+                num = idx + 1 if idx < len(labels) - 1 else 0
+                line = f"{num}. {label}"
+                if idx == current:
+                    stdscr.attron(curses.A_REVERSE)
+                    stdscr.addstr(menu_start + idx, 0, line.ljust(w))
+                    stdscr.attroff(curses.A_REVERSE)
+                else:
+                    stdscr.addstr(menu_start + idx, 0, line.ljust(w))
+            out_start = h // 2
+            stdscr.hline(out_start - 1, 0, ord('-'), w)
+            for i, line in enumerate(output[-(h - out_start - 1):]):
+                stdscr.addstr(out_start + i, 0, line[: w - 1])
+            stdscr.refresh()
+            key = stdscr.getch()
+            if key == 27:  # ESC
+                break
+            elif key in (curses.KEY_UP, ord('k')):
+                current = (current - 1) % len(labels)
+            elif key in (curses.KEY_DOWN, ord('j')):
+                current = (current + 1) % len(labels)
+            elif key in (curses.KEY_ENTER, 10, 13):
+                result = handlers[current]()
+                if result == "quit":
+                    break
+            elif key == ord('0'):
+                if handlers[-1]() == "quit":
+                    break
+            elif ord('1') <= key <= ord(str(len(labels) - 1)):
+                idx = key - ord('1')
+                result = handlers[idx]()
+                if result == "quit":
+                    break
+    finally:
+        stdscr.keypad(False)
+        curses.echo()
+        curses.nocbreak()
+        curses.endwin()
+
+
+def select_list_file() -> Path | None:
+    """Display a menu of list files or create a new one."""
+    LISTS_DIR.mkdir(parents=True, exist_ok=True)
+    files = sorted(p for p in LISTS_DIR.iterdir() if p.is_file())
+    print("Available server lists:")
+    for idx, path in enumerate(files, 1):
+        print(f"{idx}. {path.name} ({count_lines(path)} lines)")
+    print("0. Create a new list file")
+    print("m. Enter a file name manually")
+    while True:
+        choice = input("Select a file by number, 0 to create new, or m for manual: ")
+        choice = choice.strip().lower()
+        if choice == "0":
+            name = input("Enter new list file name: ").strip()
+            if not name:
+                print("Name cannot be empty.")
+                continue
+            new_path = LISTS_DIR / name
+            new_path.touch(exist_ok=True)
+            subprocess.run(["vi", str(new_path)])
+            return new_path
+        if choice == "m":
+            name = input("Enter list file name: ").strip()
+            if not name:
+                print("Name cannot be empty.")
+                continue
+            manual_path = LISTS_DIR / name
+            if manual_path.exists():
+                print(f"Selected file: {manual_path.name} ({count_lines(manual_path)} lines)")
+                return manual_path
+            print(f"File not found: {name}")
+            continue
+        if choice.isdigit():
+            index = int(choice)
+            if 1 <= index <= len(files):
+                return files[index - 1]
+        print("Invalid selection. Try again.")
+
+
+def select_template_file() -> Path | None:
+    """Manage template files: select, create, or delete."""
+    TEMPLATES_DIR.mkdir(parents=True, exist_ok=True)
+    while True:
+        files = sorted(p for p in TEMPLATES_DIR.iterdir() if p.is_file())
+        print("Available templates:")
+        for idx, path in enumerate(files, 1):
+            print(f"{idx}. {path.name}")
+        print("0. Create a new template file")
+        print("m. Enter a template file name manually")
+        print("d. Delete a template file")
+        print("q. Quit without selecting")
+        choice = input("Select template by number or option: ").strip().lower()
+        if choice == "0":
+            name = input("Enter new template file name: ").strip()
+            if not name:
+                print("Name cannot be empty.")
+                continue
+            new_path = TEMPLATES_DIR / name
+            new_path.touch(exist_ok=True)
+            subprocess.run(["vi", str(new_path)])
+            return new_path
+        if choice == "m":
+            name = input("Enter template file name: ").strip()
+            if not name:
+                print("Name cannot be empty.")
+                continue
+            manual_path = TEMPLATES_DIR / name
+            if manual_path.exists():
+                print(f"Selected template: {manual_path.name}")
+                return manual_path
+            print(f"File not found: {name}")
+            continue
+        if choice == "d":
+            target = input("Enter number or name of template to delete: ").strip()
+            if target.isdigit():
+                idx = int(target)
+                if 1 <= idx <= len(files):
+                    files[idx - 1].unlink()
+                    print(f"Deleted template: {files[idx - 1].name}")
+                else:
+                    print("Invalid selection.")
+            else:
+                del_path = TEMPLATES_DIR / target
+                if del_path.exists():
+                    del_path.unlink()
+                    print(f"Deleted template: {del_path.name}")
+                else:
+                    print(f"Template not found: {target}")
+            continue
+        if choice == "q":
+            return None
+        if choice.isdigit():
+            idx = int(choice)
+            if 1 <= idx <= len(files):
+                return files[idx - 1]
+        print("Invalid selection. Try again.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=f"{VERSION_TAG} - Show managed_by info for servers via slist",
+    )
+    parser.add_argument("names", nargs="*", help="Server names")
+    parser.add_argument("--gui", action="store_true", help="Run in interactive CLI mode")
+    parser.add_argument("--list", action="store_true", help="Edit server list in vi")
+    parser.add_argument("--last", action="store_true", help="Reuse server list from last --list run")
+    parser.add_argument("--load", action="store_true", help="Select or create a list file in the lists directory")
+    parser.add_argument("--template", action="store_true", help="Manage template files in the templates directory")
+    parser.add_argument("--cc", action="store_true", help="Choose CC email address")
+
+    args = parser.parse_args()
+
+    if args.gui:
+        run_gui(args)
+        return
+
+    if args.template:
+        display_banner()
+        select_template_file()
+        return
+
+    if args.list and args.last:
+        parser.error("--list and --last cannot be used together")
+    if args.load and (args.list or args.last):
+        parser.error("--load cannot be used with --list or --last")
+    if args.names and (args.list or args.last or args.load):
+        parser.error("names cannot be combined with list-based options")
+
+    display_banner()
+    ensure_default_signature()
+    template = load_template(DEFAULT_TEMPLATE_PATH)
+    cc_address = template.get("cc")
+    if args.cc:
+        cc_address = choose_cc_address()
+    if cc_address:
+        print(f"Using CC: {cc_address}")
+    list_path: Path | None = None
+    if args.list:
+        list_path = TEMPLIST_PATH
+        if list_path.exists():
+            list_path.unlink()
+        subprocess.run(["vi", str(list_path)])
+        if not list_path.exists():
+            list_path.touch()
+        names = [line.strip() for line in list_path.read_text().splitlines() if line.strip()]
+    elif args.last:
+        list_path = TEMPLIST_PATH
+        if not list_path.exists():
+            subprocess.run(["vi", str(list_path)])
+            if not list_path.exists():
+                list_path.touch()
+        names = [line.strip() for line in list_path.read_text().splitlines() if line.strip()]
+    elif args.load:
+        list_path = select_list_file()
+        if list_path is None:
+            return
+        with list_path.open() as f:
+            names = [line.strip() for line in f if line.strip()]
+    else:
+        if not args.names:
+            parser.error("names are required unless --list, --last, or --load is used")
+        names = args.names
+
+    if list_path is not None:
+        line_count = count_lines(list_path)
+        print(f"Processing file: {list_path.name} ({line_count} lines)")
+
+    show_managed_by(names)
+
+
+if __name__ == "__main__":
+    main()
+####################################
+# End of automail - Version 1.34   #
+####################################

--- a/managed_by-emailaddress.txt
+++ b/managed_by-emailaddress.txt
@@ -1,0 +1,1 @@
+ExampleManager,example@example.com

--- a/signatures/defaultsignature.txt
+++ b/signatures/defaultsignature.txt
@@ -1,0 +1,2 @@
+--
+Default Signature

--- a/templates/default_template.txt
+++ b/templates/default_template.txt
@@ -1,0 +1,7 @@
+Sender: sender@example.com
+Cc: cc@example.com
+Subject: Greetings {name}
+
+Dear {name},
+
+This is an automated message sent using the default template.


### PR DESCRIPTION
## Summary
- display manager email addresses by reading `managed_by-emailaddress.txt` whenever a `managed_by` value is found
- record the new behavior in a version‑1.34 changelog entry and bump the script’s version metadata

## Testing
- `python -m py_compile automail`
- `printf '1\n' | PATH=$PWD:$PATH TERM=dumb ./automail --cc localhost`
- `PATH=$PWD:$PATH TERM=dumb ./automail localhost`
- `printf '1\n' | PATH=$PWD:$PATH TERM=dumb ./automail --load`
- `printf 'q\n' | TERM=dumb ./automail --template`
- `PATH=$PWD:$PATH TERM=dumb ./automail --list` *(missing `vi`)*
- `TERM=dumb ./automail --gui <<'EOF'\n0\nEOF` *(curses requires a real TTY)*

------
https://chatgpt.com/codex/tasks/task_e_689c7264d05c8326857b1084dba355e4